### PR TITLE
Bugfix/introduce exchangerate intergration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <properties>
         <java.version>11</java.version>
         <lombok.version>1.18.24</lombok.version>
+        <spring-cloud.version>2021.0.4</spring-cloud.version>
     </properties>
 
     <dependencies>
@@ -40,12 +41,29 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
 
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/src/main/java/com/awin/currencyconverter/Application.java
+++ b/src/main/java/com/awin/currencyconverter/Application.java
@@ -2,8 +2,10 @@ package com.awin.currencyconverter;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class Application {
 
     public static void main(String[] args) {

--- a/src/main/java/com/awin/currencyconverter/client/exchangerate/ExchangerateClient.java
+++ b/src/main/java/com/awin/currencyconverter/client/exchangerate/ExchangerateClient.java
@@ -1,0 +1,15 @@
+package com.awin.currencyconverter.client.exchangerate;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(value = "ExchangerateClient", url = "https://api.exchangerate.host/")
+public interface ExchangerateClient {
+
+    @GetMapping(value = "/latest?base={source}&symbols={target}")
+    ResponseEntity<ExchangerateRateResponse> getRate(@PathVariable String source, @PathVariable String target);
+
+
+}

--- a/src/main/java/com/awin/currencyconverter/client/exchangerate/ExchangerateCurrencyExchangeProvider.java
+++ b/src/main/java/com/awin/currencyconverter/client/exchangerate/ExchangerateCurrencyExchangeProvider.java
@@ -1,0 +1,18 @@
+package com.awin.currencyconverter.client.exchangerate;
+
+import com.awin.currencyconverter.client.CurrencyExchangeProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExchangerateCurrencyExchangeProvider implements CurrencyExchangeProvider {
+
+    private final ExchangerateClient exchangerateClient;
+
+    @Override
+    public double getRate(String source, String target) {
+        return 0;
+    }
+
+}

--- a/src/main/java/com/awin/currencyconverter/client/exchangerate/ExchangerateRateResponse.java
+++ b/src/main/java/com/awin/currencyconverter/client/exchangerate/ExchangerateRateResponse.java
@@ -1,0 +1,18 @@
+package com.awin.currencyconverter.client.exchangerate;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ExchangerateRateResponse {
+
+     private boolean success;
+     private String base;
+     private Map<String,Double> rates;
+
+}

--- a/src/main/java/com/awin/currencyconverter/controller/CurrencyController.java
+++ b/src/main/java/com/awin/currencyconverter/controller/CurrencyController.java
@@ -1,6 +1,6 @@
 package com.awin.currencyconverter.controller;
 
-import com.awin.currencyconverter.service.CurrencyService;
+import com.awin.currencyconverter.service.CurrencyExchanger;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -10,9 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class CurrencyController {
 
-    private final CurrencyService currencyService;
+    private final CurrencyExchanger currencyService;
 
-    public CurrencyController(final CurrencyService currencyService) {
+    public CurrencyController(final CurrencyExchanger currencyService) {
         this.currencyService = currencyService;
     }
 

--- a/src/main/java/com/awin/currencyconverter/service/CurrencyExchanger.java
+++ b/src/main/java/com/awin/currencyconverter/service/CurrencyExchanger.java
@@ -1,6 +1,6 @@
 package com.awin.currencyconverter.service;
 
-public interface CurrencyService {
+public interface CurrencyExchanger {
 
     double convert(String source, String target, double amount);
 

--- a/src/main/java/com/awin/currencyconverter/service/CurrencyExchangingService.java
+++ b/src/main/java/com/awin/currencyconverter/service/CurrencyExchangingService.java
@@ -4,18 +4,14 @@ import com.awin.currencyconverter.client.CurrencyExchangeProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/**
- * TODO: Implementation of this class has to be backed by https://api.exchangerate.host/latest?base=EUR&symbols=AUD,CAD,CHF,CNY,GBP,JPY,USD
- */
 @Service
 @RequiredArgsConstructor
-public class CurrencyExchangeRateService implements CurrencyService {
+public class CurrencyExchangingService implements CurrencyExchanger {
 
     private final CurrencyExchangeProvider currencyExchangeProvider;
 
     @Override
     public double convert(String source, String target, double amount) {
-
         double rate = currencyExchangeProvider.getRate(source, target);
         return amount*rate;
     }

--- a/src/test/java/com/awin/currencyconverter/client/exchangerate/ExchangerateClientIntegrationTest.java
+++ b/src/test/java/com/awin/currencyconverter/client/exchangerate/ExchangerateClientIntegrationTest.java
@@ -1,0 +1,39 @@
+package com.awin.currencyconverter.client.exchangerate;
+
+import org.assertj.core.util.DateUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ExchangerateClientIntegrationTest {
+
+    @Autowired
+    private ExchangerateClient exchangerateClient;
+
+    @Test
+    void should_receive_exchange_rate_from_Exchangerate_api() {
+
+        //GIVEN
+        String source ="EUR";
+        String target ="PLN";
+
+        //WHEN
+        ResponseEntity<ExchangerateRateResponse> response = exchangerateClient.getRate(source, target);
+
+        //THEN
+        assertTrue(response.getStatusCode().is2xxSuccessful());
+        assertNotNull(response.getBody());
+
+        ExchangerateRateResponse rate = response.getBody();
+
+        assertTrue(rate.isSuccess());
+        assertEquals(source, rate.getBase());
+        assertEquals(1, rate.getRates().size());
+        assertTrue(rate.getRates().containsKey(target));
+
+    }
+}


### PR DESCRIPTION
Introducing integration with https://api.exchangerate.host/ as required.

integration was added as a client class using Feign client due to the simplicity to create a simple client using a declarative style.

the client is wrapped by a provider which implements the CurrencyExchangeProvider interface. This interface will allow loose coupling making it simple to use different currency rate providers and also changing they client type (moving to a RestClient or Web client for example)