### PR TITLE
Adding support to convert to multiple targets

### DIFF
--- a/src/main/java/com/awin/currencyconverter/api/exchange/CurrenciesResponse.java
+++ b/src/main/java/com/awin/currencyconverter/api/exchange/CurrenciesResponse.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @AllArgsConstructor
-@NoArgsConstructor
 @Builder
 @Getter
 public class CurrenciesResponse {

--- a/src/main/java/com/awin/currencyconverter/api/exchange/CurrencyExchangeController.java
+++ b/src/main/java/com/awin/currencyconverter/api/exchange/CurrencyExchangeController.java
@@ -3,6 +3,7 @@ package com.awin.currencyconverter.api.exchange;
 import com.awin.currencyconverter.domain.exchange.Currencies;
 import com.awin.currencyconverter.domain.exchange.CurrencyConversion;
 import com.awin.currencyconverter.domain.exchange.CurrencyExchange;
+import com.awin.currencyconverter.domain.exchange.MultiCurrencyConversion;
 import org.springframework.http.MediaType;
 
 import org.springframework.validation.annotation.Validated;
@@ -10,7 +11,10 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Positive;
+
+import java.util.List;
 
 import static com.awin.currencyconverter.domain.exchange.CurrencyExchangeServiceRequests.*;
 
@@ -50,6 +54,26 @@ public class CurrencyExchangeController {
 
         return CurrencyConversionResponse.from(currencyConversion);
     }
+
+    @GetMapping(value = "/multi-convert", produces = MediaType.APPLICATION_JSON_VALUE)
+    public MultiCurrencyConversionResponse multiConvert(
+            @Valid @NotBlank(message = "source must not be empty") @RequestParam("source") String source,
+            @Valid @NotEmpty(message = "target must not be empty") @RequestParam("target") String[] targets,
+            @Valid @Positive(message = "amount must be a positive number") @RequestParam("amount") double amount
+    ) {
+
+        MultiCurrencyConversionDetails conversionDetails = MultiCurrencyConversionDetails.builder()
+                .source(source)
+                .targets(List.of(targets))
+                .amount(amount)
+                .build();
+
+        MultiCurrencyConversion multiCurrencyConversion = currencyService.multiConvert(conversionDetails);
+
+        return MultiCurrencyConversionResponse.from(multiCurrencyConversion);
+    }
+
+
 
 
 

--- a/src/main/java/com/awin/currencyconverter/api/exchange/MultiCurrencyConversionResponse.java
+++ b/src/main/java/com/awin/currencyconverter/api/exchange/MultiCurrencyConversionResponse.java
@@ -1,0 +1,32 @@
+package com.awin.currencyconverter.api.exchange;
+
+import com.awin.currencyconverter.domain.exchange.Currencies;
+import com.awin.currencyconverter.domain.exchange.CurrencyConversion;
+import com.awin.currencyconverter.domain.exchange.MultiCurrencyConversion;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class MultiCurrencyConversionResponse {
+
+    private String source;
+    private double amount;
+    private Map<String,Double> rates;
+    private Map<String,Double> converted;
+
+    public static MultiCurrencyConversionResponse from(MultiCurrencyConversion multiCurrencyConversion) {
+        return MultiCurrencyConversionResponse.builder()
+                .source(multiCurrencyConversion.getSource())
+                .amount(multiCurrencyConversion.getAmount())
+                .rates(multiCurrencyConversion.getRates())
+                .converted(multiCurrencyConversion.getConversions())
+                .build();
+
+    }
+}

--- a/src/main/java/com/awin/currencyconverter/client/CurrencyExchangeProvider.java
+++ b/src/main/java/com/awin/currencyconverter/client/CurrencyExchangeProvider.java
@@ -1,10 +1,13 @@
 package com.awin.currencyconverter.client;
 
+import java.util.List;
 import java.util.Map;
 
 public interface CurrencyExchangeProvider {
 
     double getRate(String source, String target);
+
+    Map<String,Double> getRates(String source, List<String> target);
 
     Map<String , String> getCurrencies();
 

--- a/src/main/java/com/awin/currencyconverter/client/exchangerate/responses/ExchangerateRateResponse.java
+++ b/src/main/java/com/awin/currencyconverter/client/exchangerate/responses/ExchangerateRateResponse.java
@@ -1,9 +1,6 @@
 package com.awin.currencyconverter.client.exchangerate.responses;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.Map;
 import java.util.Optional;
@@ -16,6 +13,7 @@ public class ExchangerateRateResponse {
 
      private boolean success;
      private String base;
+     @Singular
      private Map<String,Double> rates;
 
      public Optional<Double> getRate(String target){

--- a/src/main/java/com/awin/currencyconverter/domain/exchange/CurrencyExchange.java
+++ b/src/main/java/com/awin/currencyconverter/domain/exchange/CurrencyExchange.java
@@ -7,4 +7,6 @@ public interface CurrencyExchange {
     CurrencyConversion convert(CurrencyConversionDetails conversionDetails);
 
     Currencies getCurrencies();
+
+    MultiCurrencyConversion multiConvert(MultiCurrencyConversionDetails details);
 }

--- a/src/main/java/com/awin/currencyconverter/domain/exchange/CurrencyExchangeServiceRequests.java
+++ b/src/main/java/com/awin/currencyconverter/domain/exchange/CurrencyExchangeServiceRequests.java
@@ -1,9 +1,14 @@
 package com.awin.currencyconverter.domain.exchange;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
+
+import java.util.List;
+
 
 public class CurrencyExchangeServiceRequests {
+
+    private CurrencyExchangeServiceRequests() {
+    }
 
     @Getter
     @Builder
@@ -11,8 +16,18 @@ public class CurrencyExchangeServiceRequests {
         private String target;
         private String source;
         private double amount;
+    }
+
+    @Getter
+    @Builder
+    public static class MultiCurrencyConversionDetails{
+        @Singular
+        private List<String> targets;
+        private String source;
+        private double amount;
 
     }
+
 
 
 }

--- a/src/main/java/com/awin/currencyconverter/domain/exchange/MultiCurrencyConversion.java
+++ b/src/main/java/com/awin/currencyconverter/domain/exchange/MultiCurrencyConversion.java
@@ -1,0 +1,30 @@
+package com.awin.currencyconverter.domain.exchange;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Singular;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class MultiCurrencyConversion {
+
+    @NonNull
+    private List<String> targets;
+
+    @NonNull
+    private String source;
+
+    private double amount;
+
+    @NonNull
+    private Map<String, Double> rates;
+
+    @NonNull
+    @Singular
+    private Map<String, Double> conversions;
+
+}

--- a/src/test/java/com/awin/currencyconverter/client/exchangerate/CurrencyExchangeControllerIntegrationTest.java
+++ b/src/test/java/com/awin/currencyconverter/client/exchangerate/CurrencyExchangeControllerIntegrationTest.java
@@ -2,6 +2,8 @@ package com.awin.currencyconverter.client.exchangerate;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,7 +35,7 @@ class CurrencyExchangeControllerIntegrationTest {
         String source = "EUR";
         String target = "PLN";
 
-        when(exchangerateClient.getRate(source,target)).thenReturn(ExchangerateClientResponseFixture.rateWithStatus200(rate));
+        when(exchangerateClient.getRate(source, target)).thenReturn(ExchangerateClientResponseFixture.rateWithStatus200(rate));
         when(exchangerateClient.getAvailableCurrencies()).thenReturn(ExchangerateClientResponseFixture.availableCurrencies200());
 
         //WHEN+THEN
@@ -46,17 +48,15 @@ class CurrencyExchangeControllerIntegrationTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.converted").value(expected));
     }
 
-
-    @Test
-    void should_return_api_error_for_invalid_source () throws Exception {
+    @ParameterizedTest()
+    @CsvSource({"INVALID,PLN", "PLN,INVALID"})
+    void should_return_api_error_for_invalid_currencies(String source, String target ) throws Exception {
 
         //GIVEN
         double amount = 2;
         double rate = 2;
-        String source = "INVALID";
-        String target = "PLN";
 
-        when(exchangerateClient.getRate(source,target)).thenReturn(ExchangerateClientResponseFixture.rateWithStatus200(rate));
+        when(exchangerateClient.getRate(source, target)).thenReturn(ExchangerateClientResponseFixture.rateWithStatus200(rate));
         when(exchangerateClient.getAvailableCurrencies()).thenReturn(ExchangerateClientResponseFixture.availableCurrencies200());
 
         //WHEN+THEN
@@ -69,20 +69,67 @@ class CurrencyExchangeControllerIntegrationTest {
     }
 
 
+
     @Test
-    void should_return_api_error_for_invalid_target () throws Exception {
+    void should_convert_EUR_to_PLN_AND_USD_when_multi_convert() throws Exception {
+
+        //GIVEN
+        double amount = 2;
+        double usdRate = 2;
+        double plnRate = 5;
+
+        String source = "EUR";
+        String target = "PLN,USD";
+
+        when(exchangerateClient.getRate(source, target)).thenReturn(ExchangerateClientResponseFixture.multiRateWithStatus200(plnRate, usdRate));
+        when(exchangerateClient.getAvailableCurrencies()).thenReturn(ExchangerateClientResponseFixture.availableCurrencies200());
+
+        //WHEN+THEN
+        this.mockMvc.perform(get(String.format("/currencies/multi-convert?source=%s&target=%s&amount=%s", source, target, amount)))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.source").value(source))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.amount").value(amount))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.rates").value(Matchers.hasEntry("PLN",plnRate)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.rates").value(Matchers.hasEntry("USD",usdRate)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.converted").value(Matchers.hasEntry("USD",usdRate *amount)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.converted").value(Matchers.hasEntry("PLN",plnRate *amount)));
+    }
+
+    @Test
+    void should_return_api_error_for_invalid_target_when_multi_conversion() throws Exception {
 
         //GIVEN
         double amount = 2;
         double rate = 2;
         String source = "EUR";
-        String target = "INVALID";
+        String target = "PLN,INVALID";
 
-        when(exchangerateClient.getRate(source,target)).thenReturn(ExchangerateClientResponseFixture.rateWithStatus200(rate));
+        when(exchangerateClient.getRate(source, target)).thenReturn(ExchangerateClientResponseFixture.rateWithStatus200(rate));
         when(exchangerateClient.getAvailableCurrencies()).thenReturn(ExchangerateClientResponseFixture.availableCurrencies200());
 
         //WHEN+THEN
-        this.mockMvc.perform(get(String.format("/currencies/convert?source=%s&target=%s&amount=%s", source, target, amount)))
+        this.mockMvc.perform(get(String.format("/currencies/multi-convert?source=%s&target=%s&amount=%s", source, target, amount)))
+                .andExpect(status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.type").value("currency not available"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("\"INVALID\" is not an available currency."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value(400));
+
+    }
+
+    @Test
+    void should_return_api_error_for_invalid_source_when_multi_conversion() throws Exception {
+
+        //GIVEN
+        double amount = 2;
+        double rate = 2;
+        String source = "INVALID";
+        String target = "PLN,EUR";
+
+        when(exchangerateClient.getRate(source, target)).thenReturn(ExchangerateClientResponseFixture.rateWithStatus200(rate));
+        when(exchangerateClient.getAvailableCurrencies()).thenReturn(ExchangerateClientResponseFixture.availableCurrencies200());
+
+        //WHEN+THEN
+        this.mockMvc.perform(get(String.format("/currencies/multi-convert?source=%s&target=%s&amount=%s", source, target, amount)))
                 .andExpect(status().isBadRequest())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.type").value("currency not available"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("\"INVALID\" is not an available currency."))

--- a/src/test/java/com/awin/currencyconverter/client/exchangerate/ExchangerateClientResponseFixture.java
+++ b/src/test/java/com/awin/currencyconverter/client/exchangerate/ExchangerateClientResponseFixture.java
@@ -14,7 +14,20 @@ public class ExchangerateClientResponseFixture {
         ExchangerateRateResponse fixture = ExchangerateRateResponse.builder()
                 .base("EUR")
                 .success(true)
-                .rates(Map.of("PLN", 2d))
+                .rates(Map.of("PLN", expectedRate))
+                .build();
+
+        return ResponseEntity.ok(fixture);
+
+    }
+
+    public static ResponseEntity<ExchangerateRateResponse> multiRateWithStatus200(Double expectedRatePLN, Double expectedRateUSD ) {
+
+        ExchangerateRateResponse fixture = ExchangerateRateResponse.builder()
+                .base("EUR")
+                .success(true)
+                .rate("PLN", expectedRatePLN)
+                .rate("USD", expectedRateUSD)
                 .build();
 
         return ResponseEntity.ok(fixture);
@@ -38,6 +51,7 @@ public class ExchangerateClientResponseFixture {
                 .success(true)
                 .symbol("PLN", new ExchangerateAvailableCurrenciesResponse.Symbol("Polish Zloty", "PLN"))
                 .symbol("EUR", new ExchangerateAvailableCurrenciesResponse.Symbol("Euro", "EUR"))
+                .symbol("USD", new ExchangerateAvailableCurrenciesResponse.Symbol("Dollar", "USD"))
                 .build();
 
         return ResponseEntity.ok(response);

--- a/src/test/java/com/awin/currencyconverter/client/exchangerate/ExchangerateCurrencyExchangeProviderTest.java
+++ b/src/test/java/com/awin/currencyconverter/client/exchangerate/ExchangerateCurrencyExchangeProviderTest.java
@@ -151,12 +151,12 @@ class ExchangerateCurrencyExchangeProviderTest {
     void should_return_map_with_available_currencies() {
 
         //GIVEN
-        int expectedAvailableCurrenciesCount = 2;
+        int expectedAvailableCurrenciesCountOnFixture = 3;
         when(client.getAvailableCurrencies()).thenReturn(ExchangerateClientResponseFixture.availableCurrencies200());
 
 
         //WHEN+THEN
-        assertEquals(expectedAvailableCurrenciesCount, provider.getCurrencies().size());
+        assertEquals(expectedAvailableCurrenciesCountOnFixture, provider.getCurrencies().size());
         assertTrue(provider.getCurrencies().containsKey("EUR"));
         assertTrue(provider.getCurrencies().containsKey("PLN"));
     }

--- a/src/test/java/com/awin/currencyconverter/domain/exchange/CurrencyExchangeServiceTest.java
+++ b/src/test/java/com/awin/currencyconverter/domain/exchange/CurrencyExchangeServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.awin.currencyconverter.domain.exchange.CurrencyExchangeServiceRequests.*;
@@ -60,5 +61,39 @@ class CurrencyExchangeServiceTest {
         //THEN
         assertEquals(1,currencies.availableCurrencies.size());
         assertTrue(currencies.availableCurrencies.stream().anyMatch(c -> c.getCode().equals("EUR")));
+    }
+
+    @Test
+    void should_return_conversion_from_multiple_currencies() {
+        //GIVEN:
+        String source = "EUR";
+        List<String> targets = List.of("PLN","USD");
+        double amount = 2d;
+        Double expectedRatePLN = 2d;
+        Double expectedRateUSD = 3d;
+        Double expectedConversionPLN = 4d;
+        Double expectedConversionUSD = 6d;
+
+        MultiCurrencyConversionDetails details = MultiCurrencyConversionDetails.builder()
+                .target("PLN")
+                .target("USD")
+                .amount(amount)
+                .source(source)
+                .build();
+
+
+        Map<String, Double> rates = Map.of("PLN", expectedRatePLN, "USD", expectedRateUSD);
+
+        when(currencyExchangeProvider.getRates(source, targets)).thenReturn(rates);
+
+        //WHEN
+        MultiCurrencyConversion conversions = currencyExchangeService.multiConvert(details);
+
+        //THEN
+        assertEquals(2, conversions.getConversions().size());
+        assertEquals(expectedConversionPLN, conversions.getConversions().get("PLN"));
+        assertEquals(expectedConversionUSD, conversions.getConversions().get("USD"));
+        assertEquals(expectedRatePLN, conversions.getRates().get("PLN"));
+        assertEquals(expectedRateUSD, conversions.getRates().get("USD"));
     }
 }


### PR DESCRIPTION
this pr adds support to retrieve multiple conversions aggregated in on a single response.

Such functionality can help to save calls to the service in case it is aimed at the rates in multiple currencies for example (sending amount equals 1)